### PR TITLE
Fix SQS receive limit function

### DIFF
--- a/tests/integration/SqsIntegrationTest.php
+++ b/tests/integration/SqsIntegrationTest.php
@@ -86,29 +86,6 @@ class SqsIntegrationTest extends TestCase
         $this->assertCount(1, $msgs);
     }
 
-    public function testReceiveRetry()
-    {
-        $url = $this->stubCreateQueue();
-        $timeout = $this->stubQueueVisibilityTimeout($url);
-
-        $receiveModel = m::mock('Guzzle\Service\Resource\Model');
-        $receiveModel->shouldReceive('getPath')->with('Messages')->times(SqsAdapter::RETRY_COUNT)->andReturn([]);
-
-        $this->sqsClient->shouldReceive('receiveMessage')->with([
-            'QueueUrl' => $url,
-            'AttributeNames' => ['All'],
-            'MaxNumberOfMessages' => SqsAdapter::BATCHSIZE_RECEIVE,
-            'VisibilityTimeout' => $timeout
-        ])->times(SqsAdapter::RETRY_COUNT)->andReturn($receiveModel);
-
-        $msgs = [];
-        $this->client->receive(function ($msg) use (&$msgs) {
-            $msgs[] = $msg;
-        }, null);
-
-        $this->assertCount(0, $msgs);
-    }
-
     public function testReceiveWithReceiveMessageReturningLessThanMaxNumberOfMessages()
     {
         $url = $this->stubCreateQueue();


### PR DESCRIPTION
@h-bragg @sjparkinson 

Prior to this change, if you specify a limit of more than 10 when polling an SQS queue, it would process at most 10 items from the queue (and probably fewer). This change now means that the function will process precisely the limit specified, and will wait indefinitely if there are fewer items on the queue than the limit. Personally I think this is how this function should work. What do you think?
