### PR TITLE
Add the mockery test listener to the phpunit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,4 +38,10 @@
 
     </logging>
 
+    <listeners>
+
+        <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
+
+    </listeners>
+
 </phpunit>

--- a/src/Handler/NullAcknowledgementHandler.php
+++ b/src/Handler/NullAcknowledgementHandler.php
@@ -27,7 +27,7 @@ class NullAcknowledgementHandler extends AbstractAcknowledgementHandler
         AdapterInterface $adapter,
         $result = null
     ) {
-        // Don't acknowledge
+        // Don't acknowledge.
     }
 
     /**
@@ -35,6 +35,6 @@ class NullAcknowledgementHandler extends AbstractAcknowledgementHandler
      */
     protected function flush(AdapterInterface $adapter)
     {
-        // Nothing to flush
+        // Nothing to flush.
     }
 }

--- a/tests/unit/Handler/BatchAcknowledgementHandlerTest.php
+++ b/tests/unit/Handler/BatchAcknowledgementHandlerTest.php
@@ -74,10 +74,11 @@ class BatchAcknowledgementHandlerTest extends TestCase
 
         $this->messageA->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
         $this->messageB->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
-        $this->messageC->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
+
         $this->adapter->shouldReceive('acknowledge')->once()->with([$this->messageA]);
 
         $this->setExpectedException('RuntimeException', 'foo');
+
         $handler($this->messages, $this->adapter, function ($msg) {
             if ($msg === $this->messageB) {
                 throw new RuntimeException('foo');

--- a/tests/unit/Handler/EagerAcknowledgementHandlerTest.php
+++ b/tests/unit/Handler/EagerAcknowledgementHandlerTest.php
@@ -81,12 +81,12 @@ class EagerAcknowledgementHandlerTest extends TestCase
 
         $this->messageA->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
         $this->messageB->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
-        $this->messageC->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
 
         // @see https://github.com/padraic/mockery/issues/331
         $this->adapter->shouldReceive('acknowledge')->once()->with(m::mustBe([$this->messageA]));
 
         $this->setExpectedException('RuntimeException', 'foo');
+
         $handler($this->messages, $this->adapter, function ($msg) {
             if ($msg === $this->messageB) {
                 throw new RuntimeException('foo');

--- a/tests/unit/Handler/NullAcknowledgementHandlerTest.php
+++ b/tests/unit/Handler/NullAcknowledgementHandlerTest.php
@@ -72,9 +72,9 @@ class NullAcknowledgementHandlerTest extends TestCase
 
         $this->messageA->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
         $this->messageB->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
-        $this->messageC->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
 
         $this->setExpectedException('RuntimeException', 'foo');
+
         $handler($this->messages, $this->adapter, function ($msg) {
             if ($msg === $this->messageB) {
                 throw new RuntimeException('foo');


### PR DESCRIPTION
We were having some issues with Mockery expectation validation in #9, turns out it was because we were not calling `Mockery::close()`.

This PR adds the bundled mockery test listener to the phpunit config.

See http://docs.mockery.io/en/latest/reference/phpunit_integration.html.

There were three errors that resulted in adding the listener, which these changes "resolve".

I couldn't work out if Jake intended there to be three calls to `isValid` in all the handlers, hence the PR to get a sanity check :confused:.
