### PR TITLE
ArrayAdapter throws OutOfBoundsException when empty

### DIFF
--- a/src/Adapter/ArrayAdapter.php
+++ b/src/Adapter/ArrayAdapter.php
@@ -24,7 +24,7 @@ final class ArrayAdapter implements AdapterInterface
     /**
      * @param MessageInterface[]
      */
-    protected $queue;
+    protected $queue = [];
 
     /**
      * @param MessageInterface[] $messages
@@ -49,9 +49,15 @@ final class ArrayAdapter implements AdapterInterface
      */
     public function dequeue(MessageFactoryInterface $factory, $limit)
     {
-        $total = null === $limit ? count($this->queue) : $limit;
+        /**
+         * If {@see $limit} is null then {@see LimitIterator} should be passed -1 as the count
+         * to avoid throwing OutOfBoundsException.
+         *
+         * @link https://github.com/php/php-src/blob/php-5.6.12/ext/spl/internal/limititerator.inc#L60-L62
+         */
+        $count = (null === $limit) ? -1 : $limit;
 
-        return new LimitIterator(new ArrayIterator($this->queue), 0, $total);
+        return new LimitIterator(new ArrayIterator($this->queue), 0, $count);
     }
 
     /**

--- a/tests/integration/ArrayIntegrationTest.php
+++ b/tests/integration/ArrayIntegrationTest.php
@@ -54,6 +54,30 @@ class ArrayIntegrationTest extends TestCase
         assertThat($msgs, is(identicalTo($this->messages)));
     }
 
+    public function testReceiveWithNoMessages()
+    {
+        $client = new Client(new ArrayAdapter());
+
+        $msgs = [];
+        $client->receive(function ($msg) use (&$msgs) {
+            $msgs[] = $msg;
+        }, null);
+
+        assertThat($msgs, is(emptyArray()));
+    }
+
+    public function testReceiveWithLimitAndNoMessages()
+    {
+        $client = new Client(new ArrayAdapter());
+
+        $msgs = [];
+        $client->receive(function ($msg) use (&$msgs) {
+            $msgs[] = $msg;
+        }, 10);
+
+        assertThat($msgs, is(emptyArray()));
+    }
+
     public function testSend()
     {
         $this->client->send([$this->client->create('foo')]);

--- a/tests/unit/Adapter/ArrayAdapterTest.php
+++ b/tests/unit/Adapter/ArrayAdapterTest.php
@@ -75,6 +75,24 @@ class ArrayAdapterTest extends TestCase
         assertThat(iterator_to_array($iterator), is(identicalTo($this->messages)));
     }
 
+    public function testDequeueWithNoMessages()
+    {
+        $adapter = new ArrayAdapter();
+
+        $iterator = $adapter->dequeue($this->factory, null);
+
+        assertThat(iterator_to_array($iterator), is(emptyArray()));
+    }
+
+    public function testDequeueWithLimitAndNoMessages()
+    {
+        $adapter = new ArrayAdapter();
+
+        $iterator = $adapter->dequeue($this->factory, 10);
+
+        assertThat(iterator_to_array($iterator), is(emptyArray()));
+    }
+
     public function testEnqueue()
     {
         $messageA = m::mock('Graze\Queue\Message\MessageInterface');


### PR DESCRIPTION
I came across this case when implementing #14.

Before defaulting the `$queue` property to an empty array the following error occurred:

```
InvalidArgumentException: Passed variable is not an array or object, using empty array instead
```

Now we get an `OutOfBoundsException` from the `foreach` call in `AbstractAcknowledgementHandler`.

Apparently `LimitIterator` is throwing the exception, you can see the source in hhvm: https://github.com/facebook/hhvm/blob/master/hphp/system/php/spl/iterators/LimitIterator.php#L106-L110