### PR TITLE
:arrow_up: Updating graze/data-structure dependency to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 
     "require": {
         "php": ">=5.6",
-        "graze/data-structure": "^1.0"
+        "graze/data-structure": "^2.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
The breaking change from 1.0 to 2.0 was because 1.0 was supporting PHP 5.3 and 2.0 only supports PHP 5.5+ this should only result in a minor change to graze/queue since it already only supports PHP 5.5+.