### PR TITLE
use the result to determine acknowldegement

### DIFF
--- a/src/Handler/ResultAcknowledgementHandler.php
+++ b/src/Handler/ResultAcknowledgementHandler.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of graze/queue.
+ *
+ * Copyright (c) 2015 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/queue/blob/master/LICENSE MIT
+ *
+ * @link    https://github.com/graze/queue
+ */
+
+namespace Graze\Queue\Handler;
+
+use Graze\Queue\Adapter\AdapterInterface;
+use Graze\Queue\Message\MessageInterface;
+
+class ResultAcknowledgementHandler extends AbstractAcknowledgementHandler
+{
+    /**
+     * @var AbstractAcknowledgementHandler
+     */
+    private $passThrough;
+
+    /**
+     * @var callable
+     */
+    private $isValid;
+
+    /**
+     * ResultAcknowledgementHandler constructor.
+     *
+     * @param callable                       $isValid
+     * @param AbstractAcknowledgementHandler $passThrough
+     */
+    public function __construct(callable $isValid, AbstractAcknowledgementHandler $passThrough = null)
+    {
+        $this->isValid = $isValid;
+        $this->passThrough = $passThrough ?: new EagerAcknowledgementHandler();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function acknowledge(
+        MessageInterface $message,
+        AdapterInterface $adapter,
+        $result = null
+    ) {
+        if (call_user_func($this->isValid, $result)) {
+            $this->passThrough->acknowledge($message, $adapter, $result);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function flush(AdapterInterface $adapter)
+    {
+        $this->passThrough->flush($adapter);
+    }
+}

--- a/tests/unit/Handler/ResultAcknowledgementHandlerTest.php
+++ b/tests/unit/Handler/ResultAcknowledgementHandlerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * This file is part of graze/queue.
+ *
+ * Copyright (c) 2015 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/queue/blob/master/LICENSE MIT
+ *
+ * @link    https://github.com/graze/queue
+ */
+
+namespace Graze\Queue\Handler;
+
+use ArrayIterator;
+use Closure;
+use Graze\Queue\Adapter\AdapterInterface;
+use Graze\Queue\Message\MessageInterface;
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class ResultAcknowledgementHandlerTest extends TestCase
+{
+    /**
+     * @var AdapterInterface|MockInterface
+     */
+    private $adapter;
+
+    /**
+     * @var AbstractAcknowledgementHandler|MockInterface
+     */
+    private $passThrough;
+
+    /**
+     * @var ResultAcknowledgementHandler
+     */
+    private $handler;
+
+    /**
+     * @var MessageInterface|MockInterface
+     */
+    private $message;
+
+    /**
+     * @var ArrayIterator
+     */
+    private $messages;
+
+    public function setUp()
+    {
+        $this->adapter = m::mock('Graze\Queue\Adapter\AdapterInterface');
+
+        $this->message = m::mock('Graze\Queue\Message\MessageInterface');
+        $this->messages = new ArrayIterator([$this->message]);
+
+        $this->passThrough = new EagerAcknowledgementHandler();
+
+        $this->handler = new ResultAcknowledgementHandler(function ($result) {
+            return $result === true;
+        }, $this->passThrough);
+    }
+
+    public function testHandleTrueResult()
+    {
+        $handler = $this->handler;
+
+        $this->message->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
+        $this->adapter->shouldReceive('acknowledge')->once()->with(m::mustBe([$this->message]));
+
+        $msgs = [];
+        $handler($this->messages, $this->adapter, function ($msg, Closure $done) use (&$msgs) {
+            $msgs[] = $msg;
+            return true;
+        });
+
+        assertThat($msgs, is(identicalTo(iterator_to_array($this->messages))));
+    }
+
+    public function testHandleNonTrueResponse()
+    {
+        $handler = $this->handler;
+
+        $this->message->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
+
+        $handler($this->messages, $this->adapter, function ($msg, Closure $done) use (&$msgs) {
+            return false;
+        });
+    }
+
+    public function testCustomResultAcknowledgementHandler()
+    {
+        $handler = new ResultAcknowledgementHandler(function ($result) {
+            return $result === false;
+        }, $this->passThrough);
+
+        $this->message->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
+        $this->adapter->shouldReceive('acknowledge')->once()->with(m::mustBe([$this->message]));
+
+        $handler($this->messages, $this->adapter, function ($msg) {
+            return false;
+        });
+    }
+
+    public function testDefaultHandlerIsEagerHandler()
+    {
+        $handler = new ResultAcknowledgementHandler(function ($result) {
+            return $result === 'true';
+        });
+
+        $this->message->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
+        $this->adapter->shouldReceive('acknowledge')->once()->with(m::mustBe([$this->message]));
+
+        $handler($this->messages, $this->adapter, function ($msg) {
+            return 'true';
+        });
+    }
+}


### PR DESCRIPTION
Resolves: #23 

Not sure if this is better than adding checks to the other `AcknowledgementHandlers`.

As an aside, would the message handling / acknowledgement handling be better split out into their own interfaces. The current Handlers are sort of doing 2 things.

```php
interface MessageHandler {
    public function handle(Iterator $messages, AdapterInterface $adapter, AcknowledgerInterface $acknowledger, callable $worker);
}
class DefaultHandler implements MessageHandler {
    public function handle(Iterator $messages, AdapterInterface $adapter, AcknowledgmentInterface $acknowledger, callable $worker) {
        // Used to break from polling consumer
        $break = false;
        $done = function () use (&$break) {
            $break = true;
        };

        try {
            foreach ($messages as $message) {
                if ($message->isValid()) {
                    $result = call_user_func($worker, $message, $done);
                    $acknowledger->acknowledge($message, $adapter, $result);
                }

                if ($break) {
                    break;
                }
            }
        } catch (Exception $e) {
            $acknowledger->flush($adapter);
            throw $e;
        }

        $this->flush($adapter);
    }
}

interface AcknowledgmentInterface {
    public function acknowledge($message, $adapter, $result);
    public function flush($adapter);
}
```