### PR TITLE
Adding queue name to FailedEnqueueException [1.0]

### DIFF
--- a/src/Adapter/Exception/FailedEnqueueException.php
+++ b/src/Adapter/Exception/FailedEnqueueException.php
@@ -25,13 +25,28 @@ use Graze\Queue\Message\MessageInterface;
 class FailedEnqueueException extends AdapterException
 {
     /**
-     * @param AdapterInterface   $adapter
-     * @param MessageInterface[] $messages
-     * @param array              $debug
-     * @param Exception          $previous
+     * @var string
      */
-    public function __construct(AdapterInterface $adapter, array $messages, array $debug = [], Exception $previous = null)
+    private $queueName;
+
+    /**
+     * @param AdapterInterface      $adapter
+     * @param MessageInterface[]    $messages
+     * @param string                $queueName
+     * @param array                 $debug
+     * @param Exception             $previous
+     */
+    public function __construct(AdapterInterface $adapter, array $messages, $queueName, array $debug = [], Exception $previous = null)
     {
         parent::__construct('Failed to enqueue messages', $adapter, $messages, $debug, $previous);
+        $this->queueName = $queueName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getQueueName()
+    {
+        return $this->queueName;
     }
 }

--- a/src/Adapter/SqsAdapter.php
+++ b/src/Adapter/SqsAdapter.php
@@ -186,7 +186,7 @@ final class SqsAdapter implements AdapterInterface
         }
 
         if (! empty($failed)) {
-            throw new FailedEnqueueException($this, $failed);
+            throw new FailedEnqueueException($this, $failed, $this->name);
         }
     }
 

--- a/tests/unit/Adapter/Exception/FailedEnqueueExceptionTest.php
+++ b/tests/unit/Adapter/Exception/FailedEnqueueExceptionTest.php
@@ -24,6 +24,7 @@ class FailedEnqueueExceptionTest extends TestCase
     public function setUp()
     {
         $this->adapter = m::mock('Graze\Queue\Adapter\AdapterInterface');
+        $this->queueName = 'foobar';
         $this->debug = ['foo' => 'bar'];
 
         $this->messageA = $a = m::mock('Graze\Queue\Message\MessageInterface');
@@ -33,7 +34,7 @@ class FailedEnqueueExceptionTest extends TestCase
 
         $this->previous = new Exception();
 
-        $this->exception = new FailedEnqueueException($this->adapter, $this->messages, $this->debug, $this->previous);
+        $this->exception = new FailedEnqueueException($this->adapter, $this->messages, $this->queueName, $this->debug, $this->previous);
     }
 
     public function testInterface()
@@ -59,5 +60,10 @@ class FailedEnqueueExceptionTest extends TestCase
     public function testGetPrevious()
     {
         assertThat($this->exception->getPrevious(), is(identicalTo($this->previous)));
+    }
+
+    public function testGetQueueName()
+    {
+        assertThat($this->exception->getQueueName(), is(identicalTo($this->queueName)));
     }
 }


### PR DESCRIPTION
`FailedEnqueueException` isn't hugely useful at the moment, if I'm a client and catching it, I have little idea of what's gone on. I can pull out the failed messages and the adapter that emitted it but not the queue url/name that failed to enqueue.

This PR adds an argument to `FailedEnqueueException` to represent the name of the queue. In `SqsAdapter` I have simply used the `$this->name` var for this purpose. I don't think it's unreasonable to assume that other queue adapters will also have a unique identifier for a queue that can be used.