### PR TITLE
Adding NamedInterface to allow queue implementations expose their name

### DIFF
--- a/src/Adapter/Exception/AdapterException.php
+++ b/src/Adapter/Exception/AdapterException.php
@@ -60,7 +60,7 @@ class AdapterException extends RuntimeException
             $this->queueName = $adapter->getQueueName();
         }
 
-        parent::__construct($message, 0, $previous);
+        parent::__construct($this->queueName . ': ' . $message, 0, $previous);
     }
 
     /**

--- a/src/Adapter/Exception/AdapterException.php
+++ b/src/Adapter/Exception/AdapterException.php
@@ -17,6 +17,7 @@ namespace Graze\Queue\Adapter\Exception;
 
 use Exception;
 use Graze\Queue\Adapter\AdapterInterface;
+use Graze\Queue\Adapter\NamedInterface;
 use Graze\Queue\Message\MessageInterface;
 use RuntimeException;
 
@@ -38,6 +39,11 @@ class AdapterException extends RuntimeException
     protected $messages;
 
     /**
+     * @var string|null
+     */
+    protected $queueName;
+
+    /**
      * @param string             $message
      * @param AdapterInterface   $adapter
      * @param MessageInterface[] $messages
@@ -49,6 +55,10 @@ class AdapterException extends RuntimeException
         $this->debug = $debug;
         $this->adapter = $adapter;
         $this->messages = $messages;
+
+        if ($adapter instanceof NamedInterface) {
+            $this->queueName = $adapter->getQueueName();
+        }
 
         parent::__construct($message, 0, $previous);
     }
@@ -75,5 +85,13 @@ class AdapterException extends RuntimeException
     public function getMessages()
     {
         return $this->messages;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getQueueName()
+    {
+        return $this->queueName;
     }
 }

--- a/src/Adapter/NamedInterface.php
+++ b/src/Adapter/NamedInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of graze/queue.
+ *
+ * Copyright (c) 2017 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/queue/blob/master/LICENSE MIT
+ *
+ * @link https://github.com/graze/queue
+ */
+
+namespace Graze\Queue\Adapter;
+
+/**
+ * Attached to adapters that may be name-able, such as an SQS queue name.
+ * This is useful in some core pieces of code, especially when throwing useful exceptions.
+ */
+interface NamedInterface
+{
+    /**
+     * @return string
+     */
+    public function getQueueName();
+}

--- a/src/Adapter/SqsAdapter.php
+++ b/src/Adapter/SqsAdapter.php
@@ -41,7 +41,7 @@ use Graze\Queue\Message\MessageInterface;
  * @link http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.Sqs.SqsClient.html#_receiveMessage
  * @link http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.Sqs.SqsClient.html#_sendMessageBatch
  */
-final class SqsAdapter implements AdapterInterface
+final class SqsAdapter implements AdapterInterface, NamedInterface
 {
     const BATCHSIZE_DELETE = 10;
     const BATCHSIZE_RECEIVE = 10;
@@ -305,5 +305,13 @@ final class SqsAdapter implements AdapterInterface
         }
 
         return $this->options['VisibilityTimeout'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getQueueName()
+    {
+        return $this->name;
     }
 }

--- a/tests/unit/Adapter/Exception/AdapterExceptionTest.php
+++ b/tests/unit/Adapter/Exception/AdapterExceptionTest.php
@@ -23,8 +23,11 @@ class AdapterExceptionTest extends TestCase
 {
     public function setUp()
     {
-        $this->adapter = m::mock('Graze\Queue\Adapter\AdapterInterface');
+        $this->queueName = 'foobar';
         $this->debug = ['foo' => 'bar'];
+
+        $this->adapter = m::mock('Graze\Queue\Adapter\AdapterInterface, Graze\Queue\Adapter\NamedInterface');
+        $this->adapter->shouldReceive('getQueueName')->andReturn($this->queueName);
 
         $this->messageA = $a = m::mock('Graze\Queue\Message\MessageInterface');
         $this->messageB = $b = m::mock('Graze\Queue\Message\MessageInterface');
@@ -59,5 +62,10 @@ class AdapterExceptionTest extends TestCase
     public function testGetPrevious()
     {
         assertThat($this->exception->getPrevious(), is(identicalTo($this->previous)));
+    }
+
+    public function testGetQueueName()
+    {
+        assertThat($this->exception->getQueueName(), is(identicalTo($this->queueName)));
     }
 }


### PR DESCRIPTION
- Decided to implement this at the `AdapterException` level, seemed to make sense.
- This should only be a MINOR version bump.