### PR TITLE
Support PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 sudo: false
 
 php:
+  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ test-integration: ## Run the integration testsuite.
 	${DOCKER_RUN} vendor/bin/phpunit --colors=always --testsuite integration
 
 test-matrix: ## Run the unit tests against multiple targets.
+	make DOCKER_REPOSITORY="php:5.5-alpine" test
 	make DOCKER_REPOSITORY="php:5.6-alpine" test
 	make DOCKER_REPOSITORY="php:7.0-alpine" test
 	make DOCKER_REPOSITORY="php:7.1-alpine" test

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "aws/aws-sdk-php": "^3.0",
         "hamcrest/hamcrest-php": "^1.2",
         "mockery/mockery": "^0.9",
-        "phpunit/phpunit": "^4.0",
-        "squizlabs/php_codesniffer": "^2.0,<2.8.1",
+        "phpunit/phpunit": "^4.8",
+        "squizlabs/php_codesniffer": "^2.7,<2.8.1",
         "graze/hamcrest-test-listener": "^1.0",
         "graze/standards": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
         ]
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=5.5",
         "graze/data-structure": "^2.0"
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.0",
         "hamcrest/hamcrest-php": "^1.2",
         "mockery/mockery": "^0.9",
-        "phpunit/phpunit": "^5.0",
-        "squizlabs/php_codesniffer": "^2.7,<2.8.1",
+        "phpunit/phpunit": "^4.0",
+        "squizlabs/php_codesniffer": "^2.0,<2.8.1",
         "graze/hamcrest-test-listener": "^1.0",
         "graze/standards": "^1.0"
     },


### PR DESCRIPTION
As discussed internally, we want to continue supporting PHP 5.5 for the time being. This means:

- Changing the `Dockerfile`.
- Changing the `composer.json` platform requirement.
- Downgrading PHPUnit to `4.x`.

I also added `7.1` to `make test-matrix` for good measure.