### PR TITLE
Add Kinesis Firehose adapter and tests

### DIFF
--- a/src/Adapter/FirehoseAdapter.php
+++ b/src/Adapter/FirehoseAdapter.php
@@ -112,7 +112,7 @@ final class FirehoseAdapter implements AdapterInterface
 
             foreach ($results->get('RequestResponses') as $idx => $response) {
                 if (isset($response['ErrorCode'])) {
-                    $failed[] = $messages[$batch[$idx]['Id']];
+                    $failed[] = $batch[$idx];
                 }
             }
         }

--- a/src/Adapter/FirehoseAdapter.php
+++ b/src/Adapter/FirehoseAdapter.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * This file is part of graze/queue.
+ *
+ * Copyright (c) 2015 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/queue/blob/master/LICENSE MIT
+ *
+ * @link    https://github.com/graze/queue
+ */
+
+namespace Graze\Queue\Adapter;
+
+use Aws\Firehose\FirehoseClient;
+use Graze\Queue\Adapter\Exception\MethodNotSupportedException;
+use Graze\Queue\Adapter\Exception\FailedEnqueueException;
+use Graze\Queue\Message\MessageFactoryInterface;
+use Graze\Queue\Message\MessageInterface;
+
+/**
+ * Amazon AWS Kinesis Firehose Adapter.
+ *
+ * This method only supports the enqueue method to send messages to a Kinesiss
+ * Firehose stream
+ *
+ */
+final class FirehoseAdapter implements AdapterInterface
+{
+    const BATCHSIZE_SEND    = 100;
+
+    /** @var FirehoseClient */
+    protected $client;
+
+    /** @var array */
+    protected $options;
+
+    /** @var string */
+    protected $deliveryStreamName;
+
+    /**
+     * @param FirehoseClient $client
+     * @param string    $deliveryStreamName
+     * @param array     $options
+     */
+    public function __construct(FirehoseClient $client, $deliveryStreamName, array $options = [])
+    {
+        $this->client = $client;
+        $this->deliveryStreamName = $deliveryStreamName;
+        $this->options = $options;
+    }
+
+    /**
+     * @param MessageInterface[] $messages
+     *
+     * @throws MethodNotSupportedException
+     */
+    public function acknowledge(array $messages)
+    {
+        throw new MethodNotSupportedException(
+            'acknowledge',
+            $this,
+            $messages
+        );
+    }
+
+    /**
+     * @param MessageFactoryInterface $factory
+     * @param int                     $limit
+     *
+     * @throws MethodNotSupportedException
+     */
+    public function dequeue(MessageFactoryInterface $factory, $limit)
+    {
+        throw new MethodNotSupportedException(
+            'dequeue',
+            $this,
+            []
+        );
+    }
+
+    /**
+     * @param MessageInterface[] $messages
+     *
+     * @throws FailedEnqueueException
+     */
+    public function enqueue(array $messages)
+    {
+        $failed = [];
+        $batches = array_chunk($this->createEnqueueEntries($messages), self::BATCHSIZE_SEND);
+
+        foreach ($batches as $batch) {
+            $requestRecords = array_map(function ($a) {
+                return [
+                    'Data' => json_encode($a)
+                ];
+            }, $batch);
+
+            $request = [
+                'DeliveryStreamName' => $this->deliveryStreamName,
+                'Records'  => $requestRecords,
+            ];
+
+            $results = $this->client->putRecordBatch($request);
+
+            foreach ($results->get('RequestResponses') as $idx => $response) {
+                if (isset($response['ErrorCode'])) {
+                    $failed[] = $messages[$batch[$idx]['Id']];
+                }
+            }
+        }
+
+        if (!empty($failed)) {
+            throw new FailedEnqueueException($this, $failed);
+        }
+    }
+
+    /**
+     * @throws MethodNotSupportedException
+     */
+    public function purge()
+    {
+        throw new MethodNotSupportedException(
+            'purge',
+            $this,
+            []
+        );
+    }
+
+    /**
+     * @throws MethodNotSupportedException
+     */
+    public function delete()
+    {
+        throw new MethodNotSupportedException(
+            'delete',
+            $this,
+            []
+        );
+    }
+
+    /**
+     * @param MessageInterface[] $messages
+     *
+     * @return array
+     */
+    protected function createEnqueueEntries(array $messages)
+    {
+        array_walk($messages, function (MessageInterface &$message, $id) {
+            $metadata = $message->getMetadata();
+            $message = [
+                'Id'                => $id,
+                'MessageBody'       => $message->getBody(),
+                'MessageAttributes' => $metadata->get('MessageAttributes') ?: [],
+            ];
+        });
+
+        return $messages;
+    }
+}

--- a/tests/integration/FirehoseIntegrationTest.php
+++ b/tests/integration/FirehoseIntegrationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of graze/queue.
+ *
+ * Copyright (c) 2015 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/queue/blob/master/LICENSE MIT
+ *
+ * @link    https://github.com/graze/queue
+ */
+
+namespace Graze\Queue;
+
+use Aws\ResultInterface;
+use Aws\Firehose\FirehoseClient;
+use Graze\Queue\Adapter\FirehoseAdapter;
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class FirehoseIntegrationTest extends TestCase
+{
+    /** @var string */
+    private $queueName;
+    /** @var FirehoseClient|MockInterface */
+    private $firehoseClient;
+    /** @var Client */
+    private $client;
+
+    public function setUp()
+    {
+        $this->deliveryStreamName = 'delivery_stream_foo';
+        $this->firehoseClient = m::mock(FirehoseClient::class);
+        $this->client = new Client(new FirehoseAdapter($this->firehoseClient, 'delivery_stream_foo'));
+    }
+
+    public function testSend()
+    {
+        $model = m::mock(ResultInterface::class);
+        $model->shouldReceive('get')->once()->with('RequestResponses')->andReturn([]);
+
+        $this->firehoseClient->shouldReceive('putRecordBatch')->once()->with([
+            'DeliveryStreamName' => $this->deliveryStreamName,
+            'Records' => [
+                ['Data' => json_encode(['Id' => 0, 'MessageBody' => 'foo', 'MessageAttributes' => []])]
+            ]
+        ])->andReturn($model);
+
+        $this->client->send([$this->client->create('foo')]);
+    }
+}

--- a/tests/integration/FirehoseIntegrationTest.php
+++ b/tests/integration/FirehoseIntegrationTest.php
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 class FirehoseIntegrationTest extends TestCase
 {
     /** @var string */
-    private $queueName;
+    private $deliveryStreamName;
     /** @var FirehoseClient|MockInterface */
     private $firehoseClient;
     /** @var Client */
@@ -46,7 +46,7 @@ class FirehoseIntegrationTest extends TestCase
         $this->firehoseClient->shouldReceive('putRecordBatch')->once()->with([
             'DeliveryStreamName' => $this->deliveryStreamName,
             'Records' => [
-                ['Data' => json_encode(['Id' => 0, 'MessageBody' => 'foo', 'MessageAttributes' => []])]
+                ['Data' => 'foo']
             ]
         ])->andReturn($model);
 

--- a/tests/unit/Adapter/FirehoseAdapterTest.php
+++ b/tests/unit/Adapter/FirehoseAdapterTest.php
@@ -17,7 +17,6 @@ namespace Graze\Queue\Adapter;
 
 use Aws\ResultInterface;
 use Aws\Firehose\FirehoseClient;
-use Graze\DataStructure\Container\ContainerInterface;
 use Graze\Queue\Adapter\Exception\MethodNotSupportedException;
 use Graze\Queue\Message\MessageFactoryInterface;
 use Graze\Queue\Message\MessageInterface;

--- a/tests/unit/Adapter/FirehoseAdapterTest.php
+++ b/tests/unit/Adapter/FirehoseAdapterTest.php
@@ -17,6 +17,7 @@ namespace Graze\Queue\Adapter;
 
 use Aws\ResultInterface;
 use Aws\Firehose\FirehoseClient;
+use Graze\Queue\Adapter\Exception\FailedEnqueueException;
 use Graze\Queue\Adapter\Exception\MethodNotSupportedException;
 use Graze\Queue\Message\MessageFactoryInterface;
 use Graze\Queue\Message\MessageInterface;
@@ -67,6 +68,43 @@ class FirehoseAdapterTest extends TestCase
         $this->messageC->shouldReceive('getBody')->once()->withNoArgs()->andReturn('baz');
 
         $this->model->shouldReceive('get')->once()->with('RequestResponses')->andReturn([]);
+
+        $this->client->shouldReceive('putRecordBatch')->once()->with([
+            'DeliveryStreamName' => 'foo',
+            'Records' => [
+                ['Data' => 'foo'],
+                ['Data' => 'bar'],
+                ['Data' => 'baz'],
+            ],
+        ])->andReturn($this->model);
+
+        $adapter->enqueue($this->messages);
+    }
+
+    /**
+     * @expectedException \Graze\Queue\Adapter\Exception\FailedEnqueueException
+     */
+    public function testEnqueueError()
+    {
+        $adapter = new FirehoseAdapter($this->client, 'foo');
+
+        $this->messageA->shouldReceive('getBody')->once()->withNoArgs()->andReturn('foo');
+        $this->messageB->shouldReceive('getBody')->once()->withNoArgs()->andReturn('bar');
+        $this->messageC->shouldReceive('getBody')->once()->withNoArgs()->andReturn('baz');
+
+        $this->model->shouldReceive('get')->once()->with('RequestResponses')->andReturn([
+            [
+                'ErrorCode' => 'fooError',
+                'ErrorMessage' => 'Some error message',
+                'RecordId' => 'foo',
+            ],
+            [
+                'RecordId' => 'bar',
+            ],
+            [
+                'RecordId' => 'baz',
+            ]
+        ]);
 
         $this->client->shouldReceive('putRecordBatch')->once()->with([
             'DeliveryStreamName' => 'foo',

--- a/tests/unit/Adapter/FirehoseAdapterTest.php
+++ b/tests/unit/Adapter/FirehoseAdapterTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * This file is part of graze/queue.
+ *
+ * Copyright (c) 2015 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/queue/blob/master/LICENSE MIT
+ *
+ * @link    https://github.com/graze/queue
+ */
+
+namespace Graze\Queue\Adapter;
+
+use Aws\ResultInterface;
+use Aws\Firehose\FirehoseClient;
+use Graze\DataStructure\Container\ContainerInterface;
+use Graze\Queue\Adapter\Exception\MethodNotSupportedException;
+use Graze\Queue\Message\MessageFactoryInterface;
+use Graze\Queue\Message\MessageInterface;
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class FirehoseAdapterTest extends TestCase
+{
+    /** @var MessageInterface|MockInterface */
+    private $messageA;
+    /** @var MessageInterface|MockInterface */
+    private $messageB;
+    /** @var MessageInterface|MockInterface */
+    private $messageC;
+    /** @var MessageInterface[]|MockInterface[] */
+    private $messages;
+    /** @var ResultInterface|MockInterface */
+    private $model;
+    /** @var MessageFactoryInterface|MockInterface */
+    private $factory;
+    /** @var FirehoseClient */
+    private $client;
+
+    public function setUp()
+    {
+        $this->client = m::mock(FirehoseClient::class);
+        $this->model = m::mock(ResultInterface::class);
+        $this->factory = m::mock(MessageFactoryInterface::class);
+
+        $this->messageA = $a = m::mock(MessageInterface::class);
+        $this->messageB = $b = m::mock(MessageInterface::class);
+        $this->messageC = $c = m::mock(MessageInterface::class);
+        $this->messages = [$a, $b, $c];
+    }
+
+    public function testInterface()
+    {
+        assertThat(new FirehoseAdapter($this->client, 'foo'), is(anInstanceOf('Graze\Queue\Adapter\AdapterInterface')));
+    }
+
+    public function testEnqueue()
+    {
+        $adapter = new FirehoseAdapter($this->client, 'foo');
+
+        $metadata = m::mock(ContainerInterface::class);
+        $metadata->shouldReceive('get')
+                 ->with('MessageAttributes')
+                 ->times(3)
+                 ->andReturn(null);
+
+        $this->messageA->shouldReceive('getBody')->once()->withNoArgs()->andReturn('foo');
+        $this->messageB->shouldReceive('getBody')->once()->withNoArgs()->andReturn('bar');
+        $this->messageC->shouldReceive('getBody')->once()->withNoArgs()->andReturn('baz');
+        $this->messageA->shouldReceive('getMetadata')->andReturn($metadata);
+        $this->messageB->shouldReceive('getMetadata')->andReturn($metadata);
+        $this->messageC->shouldReceive('getMetadata')->andReturn($metadata);
+
+        $this->model->shouldReceive('get')->once()->with('RequestResponses')->andReturn([]);
+
+        $this->client->shouldReceive('putRecordBatch')->once()->with([
+            'DeliveryStreamName' => 'foo',
+            'Records' => [
+                ['Data' => json_encode(['Id' => 0, 'MessageBody' => 'foo', 'MessageAttributes' => []])],
+                ['Data' => json_encode(['Id' => 1, 'MessageBody' => 'bar', 'MessageAttributes' => []])],
+                ['Data' => json_encode(['Id' => 2, 'MessageBody' => 'baz', 'MessageAttributes' => []])]
+            ],
+        ])->andReturn($this->model);
+
+        $adapter->enqueue($this->messages);
+    }
+
+    /**
+     * @expectedException \Graze\Queue\Adapter\Exception\MethodNotSupportedException
+     */
+    public function testAcknowledge()
+    {
+        $adapter = new FirehoseAdapter($this->client, 'foo');
+        $adapter->acknowledge($this->messages);
+    }
+
+    /**
+     * @expectedException \Graze\Queue\Adapter\Exception\MethodNotSupportedException
+     */
+    public function testDequeue()
+    {
+        $adapter = new FirehoseAdapter($this->client, 'foo');
+        $adapter->dequeue($this->factory, 10);
+    }
+
+    /**
+     * @expectedException \Graze\Queue\Adapter\Exception\MethodNotSupportedException
+     */
+    public function testPurge()
+    {
+        $adapter = new FirehoseAdapter($this->client, 'foo');
+        $adapter->purge();
+    }
+
+    /**
+     * @expectedException \Graze\Queue\Adapter\Exception\MethodNotSupportedException
+     */
+    public function testDelete()
+    {
+        $adapter = new FirehoseAdapter($this->client, 'foo');
+        $adapter->delete();
+    }
+}

--- a/tests/unit/Adapter/FirehoseAdapterTest.php
+++ b/tests/unit/Adapter/FirehoseAdapterTest.php
@@ -17,7 +17,6 @@ namespace Graze\Queue\Adapter;
 
 use Aws\ResultInterface;
 use Aws\Firehose\FirehoseClient;
-use Graze\Queue\Adapter\Exception\FailedEnqueueException;
 use Graze\Queue\Adapter\Exception\MethodNotSupportedException;
 use Graze\Queue\Message\MessageFactoryInterface;
 use Graze\Queue\Message\MessageInterface;
@@ -68,43 +67,6 @@ class FirehoseAdapterTest extends TestCase
         $this->messageC->shouldReceive('getBody')->once()->withNoArgs()->andReturn('baz');
 
         $this->model->shouldReceive('get')->once()->with('RequestResponses')->andReturn([]);
-
-        $this->client->shouldReceive('putRecordBatch')->once()->with([
-            'DeliveryStreamName' => 'foo',
-            'Records' => [
-                ['Data' => 'foo'],
-                ['Data' => 'bar'],
-                ['Data' => 'baz'],
-            ],
-        ])->andReturn($this->model);
-
-        $adapter->enqueue($this->messages);
-    }
-
-    /**
-     * @expectedException \Graze\Queue\Adapter\Exception\FailedEnqueueException
-     */
-    public function testEnqueueError()
-    {
-        $adapter = new FirehoseAdapter($this->client, 'foo');
-
-        $this->messageA->shouldReceive('getBody')->once()->withNoArgs()->andReturn('foo');
-        $this->messageB->shouldReceive('getBody')->once()->withNoArgs()->andReturn('bar');
-        $this->messageC->shouldReceive('getBody')->once()->withNoArgs()->andReturn('baz');
-
-        $this->model->shouldReceive('get')->once()->with('RequestResponses')->andReturn([
-            [
-                'ErrorCode' => 'fooError',
-                'ErrorMessage' => 'Some error message',
-                'RecordId' => 'foo',
-            ],
-            [
-                'RecordId' => 'bar',
-            ],
-            [
-                'RecordId' => 'baz',
-            ]
-        ]);
 
         $this->client->shouldReceive('putRecordBatch')->once()->with([
             'DeliveryStreamName' => 'foo',

--- a/tests/unit/Adapter/FirehoseAdapterTest.php
+++ b/tests/unit/Adapter/FirehoseAdapterTest.php
@@ -63,27 +63,18 @@ class FirehoseAdapterTest extends TestCase
     {
         $adapter = new FirehoseAdapter($this->client, 'foo');
 
-        $metadata = m::mock(ContainerInterface::class);
-        $metadata->shouldReceive('get')
-                 ->with('MessageAttributes')
-                 ->times(3)
-                 ->andReturn(null);
-
         $this->messageA->shouldReceive('getBody')->once()->withNoArgs()->andReturn('foo');
         $this->messageB->shouldReceive('getBody')->once()->withNoArgs()->andReturn('bar');
         $this->messageC->shouldReceive('getBody')->once()->withNoArgs()->andReturn('baz');
-        $this->messageA->shouldReceive('getMetadata')->andReturn($metadata);
-        $this->messageB->shouldReceive('getMetadata')->andReturn($metadata);
-        $this->messageC->shouldReceive('getMetadata')->andReturn($metadata);
 
         $this->model->shouldReceive('get')->once()->with('RequestResponses')->andReturn([]);
 
         $this->client->shouldReceive('putRecordBatch')->once()->with([
             'DeliveryStreamName' => 'foo',
             'Records' => [
-                ['Data' => json_encode(['Id' => 0, 'MessageBody' => 'foo', 'MessageAttributes' => []])],
-                ['Data' => json_encode(['Id' => 1, 'MessageBody' => 'bar', 'MessageAttributes' => []])],
-                ['Data' => json_encode(['Id' => 2, 'MessageBody' => 'baz', 'MessageAttributes' => []])]
+                ['Data' => 'foo'],
+                ['Data' => 'bar'],
+                ['Data' => 'baz'],
             ],
         ])->andReturn($this->model);
 


### PR DESCRIPTION
Adding an adapter to send messages to a Kinesis Firehose stream. This adapter only supports the `enqueue` function (as that's the only thing you can do to a Kinesis Firehose delivery stream).