### PR TITLE
adds a reject method to do the opposite of acknowledge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - php: 7.2
 
 install:
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
 script:
   - vendor/bin/phpcs -p --warning-severity=0 src/ tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 matrix:
   allow_failures:
     - php: nightly
+    - php: 7.2
 
 install:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 
-sudo: false
+dist: trusty
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 php:
   - 5.5
@@ -10,8 +14,6 @@ php:
   - 7.2
   - nightly
   - hhvm
-
-
 
 env:
   - 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
@@ -29,4 +31,4 @@ script:
   - vendor/bin/phpunit --coverage-clover=./tests/report/coverage.clover
 
 after_script:
-  - ./build/coverage_to_scruitinizer.sh
+  - test -f ./tests/report/coverage.clover && (wget https://scrutinizer-ci.com/ocular.phar; php ocular.phar code-coverage:upload --format=php-clover ./tests/report/coverage.clover)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,19 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - nightly
   - hhvm
+
+
 
 env:
   - 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
   - 'COMPOSER_FLAGS=""'
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 install:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/sh
 
 DOCKER ?= $(shell which docker)
-DOCKER_REPOSITORY := graze/php-alpine:test
+DOCKER_REPOSITORY := graze/php-alpine:7.0-test
 VOLUME := /opt/graze/queue
 VOLUME_MAP := -v $$(pwd):${VOLUME}
 DOCKER_RUN_BASE := ${DOCKER} run --rm -t ${VOLUME_MAP} -w ${VOLUME}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/sh
 
 DOCKER ?= $(shell which docker)
-DOCKER_REPOSITORY := graze/php-alpine:7.0-test
+DOCKER_REPOSITORY := graze/php-alpine:7.1-test
 VOLUME := /opt/graze/queue
 VOLUME_MAP := -v $$(pwd):${VOLUME}
 DOCKER_RUN_BASE := ${DOCKER} run --rm -t ${VOLUME_MAP} -w ${VOLUME}
@@ -19,10 +19,9 @@ install: ## Download the dependencies then build the image :rocket:.
 
 composer-%: ## Run a composer command, `make "composer-<command> [...]"`.
 	${DOCKER} run -t --rm \
-        -v $$(pwd):/usr/src/app \
-        -v ~/.composer:/root/composer \
-        -v ~/.ssh:/root/.ssh:ro \
-        graze/composer --no-interaction --prefer-dist $* $(filter-out $@,$(MAKECMDGOALS))
+        -v $$(pwd):/app:delegated \
+        -v ~/.composer:/tmp:delegated \
+        composer --no-interaction --prefer-dist $* $(filter-out $@,$(MAKECMDGOALS))
 
 # Testing
 
@@ -42,10 +41,10 @@ test-integration: ## Run the integration testsuite.
 	${DOCKER_RUN} vendor/bin/phpunit --colors=always --testsuite integration
 
 test-matrix: ## Run the unit tests against multiple targets.
-	make DOCKER_REPOSITORY="php:5.5-alpine" test
 	make DOCKER_REPOSITORY="php:5.6-alpine" test
 	make DOCKER_REPOSITORY="php:7.0-alpine" test
 	make DOCKER_REPOSITORY="php:7.1-alpine" test
+	make DOCKER_REPOSITORY="php:7.2-alpine" test
 	make DOCKER_REPOSITORY="hhvm/hhvm:latest" test
 
 test-coverage: ## Run all tests and output coverage to the console.

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,11 @@ DOCKER_RUN := ${DOCKER_RUN_BASE} ${DOCKER_REPOSITORY}
 
 # Building
 
-install: ## Download the dependencies then build the image :rocket:.
-	make 'composer-install --optimize-autoloader --ignore-platform-reqs'
+build: ## Download the dependencies
+	make 'composer-install --optimize-autoloader'
+
+build-update: ## Update and download the dependencies
+	make 'composer-update --optimize-autoloader'
 
 composer-%: ## Run a composer command, `make "composer-<command> [...]"`.
 	${DOCKER} run -t --rm \

--- a/build/coverage_to_scruitinizer.sh
+++ b/build/coverage_to_scruitinizer.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -ev
-
-if [[ -f ./tests/report/coverage.clover ]]; then
-    wget https://scrutinizer-ci.com/ocular.phar
-    php ocular.phar code-coverage:upload --format=php-clover ./tests/report/coverage.clover
-fi

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -24,7 +24,7 @@ use Iterator;
 interface AdapterInterface
 {
     /**
-     * Acknowledge the message (delete it from the queue)
+     * Acknowledge the messages (delete them from the queue)
      *
      * @param MessageInterface[] $messages
      *

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -24,13 +24,30 @@ use Iterator;
 interface AdapterInterface
 {
     /**
+     * Acknowledge the message (delete it from the queue)
+     *
      * @param MessageInterface[] $messages
+     *
+     * @return void
      *
      * @throws FailedAcknowledgementException
      */
     public function acknowledge(array $messages);
 
     /**
+     * Attempt to reject all the following messages (make the message immediately visible to other consumers)
+     *
+     * @param MessageInterface[] $messages
+     *
+     * @return void
+     *
+     * @throws FailedAcknowledgementException
+     */
+    public function reject(array $messages);
+
+    /**
+     * Remove up to {$limit} messages from the queue
+     *
      * @param MessageFactoryInterface $factory
      * @param int                     $limit
      *
@@ -39,18 +56,26 @@ interface AdapterInterface
     public function dequeue(MessageFactoryInterface $factory, $limit);
 
     /**
+     * Add all the messages to the queue
+     *
      * @param MessageInterface[] $messages
+     *
+     * @return void
      *
      * @throws FailedEnqueueException
      */
     public function enqueue(array $messages);
 
     /**
+     * Empty the queue
+     *
      * @return void
      */
     public function purge();
 
     /**
+     * Delete the queue
+     *
      * @return void
      */
     public function delete();

--- a/src/Adapter/ArrayAdapter.php
+++ b/src/Adapter/ArrayAdapter.php
@@ -16,6 +16,7 @@
 namespace Graze\Queue\Adapter;
 
 use ArrayIterator;
+use Graze\Queue\Adapter\Exception\FailedAcknowledgementException;
 use Graze\Queue\Message\MessageFactoryInterface;
 use Graze\Queue\Message\MessageInterface;
 use LimitIterator;
@@ -41,6 +42,20 @@ final class ArrayAdapter implements AdapterInterface
         $this->queue = array_values(array_filter($this->queue, function ($message) use ($messages) {
             return false === array_search($message, $messages, true);
         }));
+    }
+
+    /**
+     * Attempt to reject all the following messages (make the message immediately visible to other consumers)
+     *
+     * @param MessageInterface[] $messages
+     *
+     * @return void
+     *
+     * @throws FailedAcknowledgementException
+     */
+    public function reject(array $messages)
+    {
+        // do nothing, timeouts not implemented, so messages are immediately available
     }
 
     /**

--- a/src/Adapter/FirehoseAdapter.php
+++ b/src/Adapter/FirehoseAdapter.php
@@ -16,8 +16,8 @@
 namespace Graze\Queue\Adapter;
 
 use Aws\Firehose\FirehoseClient;
-use Graze\Queue\Adapter\Exception\MethodNotSupportedException;
 use Graze\Queue\Adapter\Exception\FailedEnqueueException;
+use Graze\Queue\Adapter\Exception\MethodNotSupportedException;
 use Graze\Queue\Message\MessageFactoryInterface;
 use Graze\Queue\Message\MessageInterface;
 
@@ -31,7 +31,7 @@ use Graze\Queue\Message\MessageInterface;
  */
 final class FirehoseAdapter implements AdapterInterface
 {
-    const BATCHSIZE_SEND    = 100;
+    const BATCHSIZE_SEND = 100;
 
     /** @var FirehoseClient */
     protected $client;
@@ -44,8 +44,8 @@ final class FirehoseAdapter implements AdapterInterface
 
     /**
      * @param FirehoseClient $client
-     * @param string    $deliveryStreamName
-     * @param array     $options - BatchSize <integer> The number of messages to send in each batch.
+     * @param string         $deliveryStreamName
+     * @param array          $options - BatchSize <integer> The number of messages to send in each batch.
      */
     public function __construct(FirehoseClient $client, $deliveryStreamName, array $options = [])
     {
@@ -60,6 +60,18 @@ final class FirehoseAdapter implements AdapterInterface
      * @throws MethodNotSupportedException
      */
     public function acknowledge(array $messages)
+    {
+        throw new MethodNotSupportedException(
+            __FUNCTION__,
+            $this,
+            $messages
+        );
+    }
+
+    /**
+     * @param MessageInterface[] $messages
+     */
+    public function reject(array $messages)
     {
         throw new MethodNotSupportedException(
             __FUNCTION__,
@@ -99,13 +111,14 @@ final class FirehoseAdapter implements AdapterInterface
         foreach ($batches as $batch) {
             $requestRecords = array_map(function (MessageInterface $message) {
                 return [
-                    'Data' => $message->getBody()
+                    'Data' => $message->getBody(),
                 ];
-            }, $batch);
+            },
+                $batch);
 
             $request = [
                 'DeliveryStreamName' => $this->deliveryStreamName,
-                'Records'  => $requestRecords,
+                'Records'            => $requestRecords,
             ];
 
             $results = $this->client->putRecordBatch($request);

--- a/src/Adapter/FirehoseAdapter.php
+++ b/src/Adapter/FirehoseAdapter.php
@@ -109,12 +109,14 @@ final class FirehoseAdapter implements AdapterInterface
         );
 
         foreach ($batches as $batch) {
-            $requestRecords = array_map(function (MessageInterface $message) {
-                return [
-                    'Data' => $message->getBody(),
-                ];
-            },
-                $batch);
+            $requestRecords = array_map(
+                function (MessageInterface $message) {
+                    return [
+                        'Data' => $message->getBody(),
+                    ];
+                },
+                $batch
+            );
 
             $request = [
                 'DeliveryStreamName' => $this->deliveryStreamName,

--- a/src/Adapter/SqsAdapter.php
+++ b/src/Adapter/SqsAdapter.php
@@ -173,11 +173,13 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
             }
 
             foreach ($messages as $result) {
-                yield $factory->createMessage($result['Body'],
+                yield $factory->createMessage(
+                    $result['Body'],
                     [
                         'metadata'  => $this->createMessageMetadata($result),
                         'validator' => $validator,
-                    ]);
+                    ]
+                );
             }
 
             // Decrement the number of messages remaining.
@@ -235,14 +237,16 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
      */
     protected function createDeleteEntries(array $messages)
     {
-        array_walk($messages,
+        array_walk(
+            $messages,
             function (MessageInterface &$message, $id) {
                 $metadata = $message->getMetadata();
                 $message = [
                     'Id'            => $id,
                     'ReceiptHandle' => $metadata->get('ReceiptHandle'),
                 ];
-            });
+            }
+        );
 
         return $messages;
     }
@@ -254,7 +258,8 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
      */
     protected function createRejectEntries(array $messages)
     {
-        array_walk($messages,
+        array_walk(
+            $messages,
             function (MessageInterface &$message, $id) {
                 $metadata = $message->getMetadata();
                 $message = [
@@ -262,7 +267,8 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
                     'ReceiptHandle'     => $metadata->get('ReceiptHandle'),
                     'VisibilityTimeout' => 0,
                 ];
-            });
+            }
+        );
 
         return $messages;
     }
@@ -274,7 +280,8 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
      */
     protected function createEnqueueEntries(array $messages)
     {
-        array_walk($messages,
+        array_walk(
+            $messages,
             function (MessageInterface &$message, $id) {
                 $metadata = $message->getMetadata();
                 $message = [
@@ -285,7 +292,8 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
                 if (!is_null($metadata->get('DelaySeconds'))) {
                     $message['DelaySeconds'] = $metadata->get('DelaySeconds');
                 }
-            });
+            }
+        );
 
         return $messages;
     }
@@ -297,13 +305,15 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
      */
     protected function createMessageMetadata(array $result)
     {
-        return array_intersect_key($result,
+        return array_intersect_key(
+            $result,
             [
                 'Attributes'        => [],
                 'MessageAttributes' => [],
                 'MessageId'         => null,
                 'ReceiptHandle'     => null,
-            ]);
+            ]
+        );
     }
 
     /**

--- a/src/Adapter/SqsAdapter.php
+++ b/src/Adapter/SqsAdapter.php
@@ -108,6 +108,35 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
     }
 
     /**
+     * @param MessageInterface[] $messages
+     *
+     * @throws FailedAcknowledgementException|void
+     */
+    public function reject(array $messages)
+    {
+        $url = $this->getQueueUrl();
+        $failed = [];
+        $batches = array_chunk($this->createRejectEntries($messages), self::BATCHSIZE_DELETE);
+
+        foreach ($batches as $batch) {
+            $results = $this->client->changeMessageVisibilityBatch([
+                'QueueUrl' => $url,
+                'Entries'  => $batch,
+            ]);
+
+            $map = function ($result) use ($messages) {
+                return $messages[$result['Id']];
+            };
+
+            $failed = array_merge($failed, array_map($map, $results->get('Failed') ?: []));
+        }
+
+        if (!empty($failed)) {
+            throw new FailedAcknowledgementException($this, $failed);
+        }
+    }
+
+    /**
      * @param MessageFactoryInterface $factory
      * @param int                     $limit
      *
@@ -144,10 +173,11 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
             }
 
             foreach ($messages as $result) {
-                yield $factory->createMessage($result['Body'], [
-                    'metadata'  => $this->createMessageMetadata($result),
-                    'validator' => $validator,
-                ]);
+                yield $factory->createMessage($result['Body'],
+                    [
+                        'metadata'  => $this->createMessageMetadata($result),
+                        'validator' => $validator,
+                    ]);
             }
 
             // Decrement the number of messages remaining.
@@ -205,13 +235,34 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
      */
     protected function createDeleteEntries(array $messages)
     {
-        array_walk($messages, function (MessageInterface &$message, $id) {
-            $metadata = $message->getMetadata();
-            $message = [
-                'Id'            => $id,
-                'ReceiptHandle' => $metadata->get('ReceiptHandle'),
-            ];
-        });
+        array_walk($messages,
+            function (MessageInterface &$message, $id) {
+                $metadata = $message->getMetadata();
+                $message = [
+                    'Id'            => $id,
+                    'ReceiptHandle' => $metadata->get('ReceiptHandle'),
+                ];
+            });
+
+        return $messages;
+    }
+
+    /**
+     * @param MessageInterface[] $messages
+     *
+     * @return array
+     */
+    protected function createRejectEntries(array $messages)
+    {
+        array_walk($messages,
+            function (MessageInterface &$message, $id) {
+                $metadata = $message->getMetadata();
+                $message = [
+                    'Id'                => $id,
+                    'ReceiptHandle'     => $metadata->get('ReceiptHandle'),
+                    'VisibilityTimeout' => 0,
+                ];
+            });
 
         return $messages;
     }
@@ -223,17 +274,18 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
      */
     protected function createEnqueueEntries(array $messages)
     {
-        array_walk($messages, function (MessageInterface &$message, $id) {
-            $metadata = $message->getMetadata();
-            $message = [
-                'Id'                => $id,
-                'MessageBody'       => $message->getBody(),
-                'MessageAttributes' => $metadata->get('MessageAttributes') ?: [],
-            ];
-            if (!is_null($metadata->get('DelaySeconds'))) {
-                $message['DelaySeconds'] = $metadata->get('DelaySeconds');
-            }
-        });
+        array_walk($messages,
+            function (MessageInterface &$message, $id) {
+                $metadata = $message->getMetadata();
+                $message = [
+                    'Id'                => $id,
+                    'MessageBody'       => $message->getBody(),
+                    'MessageAttributes' => $metadata->get('MessageAttributes') ?: [],
+                ];
+                if (!is_null($metadata->get('DelaySeconds'))) {
+                    $message['DelaySeconds'] = $metadata->get('DelaySeconds');
+                }
+            });
 
         return $messages;
     }
@@ -245,12 +297,13 @@ final class SqsAdapter implements AdapterInterface, NamedInterface
      */
     protected function createMessageMetadata(array $result)
     {
-        return array_intersect_key($result, [
-            'Attributes'        => [],
-            'MessageAttributes' => [],
-            'MessageId'         => null,
-            'ReceiptHandle'     => null,
-        ]);
+        return array_intersect_key($result,
+            [
+                'Attributes'        => [],
+                'MessageAttributes' => [],
+                'MessageId'         => null,
+                'ReceiptHandle'     => null,
+            ]);
     }
 
     /**

--- a/src/Handler/AbstractAcknowledgementHandler.php
+++ b/src/Handler/AbstractAcknowledgementHandler.php
@@ -34,6 +34,17 @@ abstract class AbstractAcknowledgementHandler
     );
 
     /**
+     * @param MessageInterface $message
+     * @param AdapterInterface $adapter
+     * @param mixed            $result
+     */
+    abstract protected function reject(
+        MessageInterface $message,
+        AdapterInterface $adapter,
+        $result = null
+    );
+
+    /**
      * @param AdapterInterface $adapter
      */
     abstract protected function flush(AdapterInterface $adapter);

--- a/src/Handler/EagerAcknowledgementHandler.php
+++ b/src/Handler/EagerAcknowledgementHandler.php
@@ -34,6 +34,19 @@ class EagerAcknowledgementHandler extends AbstractAcknowledgementHandler
     }
 
     /**
+     * @param MessageInterface $message
+     * @param AdapterInterface $adapter
+     * @param mixed            $result
+     */
+    protected function reject(
+        MessageInterface $message,
+        AdapterInterface $adapter,
+        $result = null
+    ) {
+        $adapter->reject([$message]);
+    }
+
+    /**
      * @param AdapterInterface $adapter
      */
     protected function flush(AdapterInterface $adapter)

--- a/src/Handler/NullAcknowledgementHandler.php
+++ b/src/Handler/NullAcknowledgementHandler.php
@@ -34,6 +34,19 @@ class NullAcknowledgementHandler extends AbstractAcknowledgementHandler
     }
 
     /**
+     * @param MessageInterface $message
+     * @param AdapterInterface $adapter
+     * @param mixed            $result
+     */
+    protected function reject(
+        MessageInterface $message,
+        AdapterInterface $adapter,
+        $result = null
+    ) {
+        // Don't reject
+    }
+
+    /**
      * @param AdapterInterface $adapter
      */
     protected function flush(AdapterInterface $adapter)

--- a/src/Handler/ResultAcknowledgementHandler.php
+++ b/src/Handler/ResultAcknowledgementHandler.php
@@ -43,7 +43,7 @@ class ResultAcknowledgementHandler extends AbstractAcknowledgementHandler
         $this->validator = $validator;
 
         /**
-         * The handler to call `acknowlege` on if {@see $validator} returns a
+         * The handler to call `acknowledge` or `reject` on if {@see $validator} returns a
          * truthy value for the given result.
          *
          * @var AbstractAcknowledgementHandler
@@ -63,7 +63,22 @@ class ResultAcknowledgementHandler extends AbstractAcknowledgementHandler
     ) {
         if (call_user_func($this->validator, $result) === true) {
             $this->handler->acknowledge($message, $adapter, $result);
+        } else {
+            $this->handler->reject($message, $adapter, $result);
         }
+    }
+
+    /**
+     * @param MessageInterface $message
+     * @param AdapterInterface $adapter
+     * @param mixed            $result
+     */
+    protected function reject(
+        MessageInterface $message,
+        AdapterInterface $adapter,
+        $result = null
+    ) {
+        $this->handler->reject($message, $adapter, $result);
     }
 
     /**

--- a/tests/unit/Adapter/ArrayAdapterTest.php
+++ b/tests/unit/Adapter/ArrayAdapterTest.php
@@ -71,6 +71,24 @@ class ArrayAdapterTest extends TestCase
         assertThat(iterator_to_array($iterator), is(identicalTo([$this->messageA, $this->messageC])));
     }
 
+    public function testReject()
+    {
+        $this->adapter->reject($this->messages);
+
+        $iterator = $this->adapter->dequeue($this->factory, 10);
+
+        assertThat(iterator_to_array($iterator), is(identicalTo($this->messages)));
+    }
+
+    public function testRejectOne()
+    {
+        $this->adapter->reject([$this->messageA]);
+
+        $iterator = $this->adapter->dequeue($this->factory, 10);
+
+        assertThat(iterator_to_array($iterator), is(identicalTo($this->messages)));
+    }
+
     public function testDequeue()
     {
         $iterator = $this->adapter->dequeue($this->factory, 10);

--- a/tests/unit/Adapter/SqsAdapterTest.php
+++ b/tests/unit/Adapter/SqsAdapterTest.php
@@ -60,12 +60,13 @@ class SqsAdapterTest extends TestCase
      */
     protected function stubCreateDequeueMessage($body, $id, $handle)
     {
-        $this->factory->shouldReceive('createMessage')->once()->with($body, m::on(function ($opts) use ($id, $handle) {
-            $meta = ['Attributes' => [], 'MessageAttributes' => [], 'MessageId' => $id, 'ReceiptHandle' => $handle];
-            $validator = isset($opts['validator']) && is_callable($opts['validator']);
+        $this->factory->shouldReceive('createMessage')->once()->with($body,
+            m::on(function ($opts) use ($id, $handle) {
+                $meta = ['Attributes' => [], 'MessageAttributes' => [], 'MessageId' => $id, 'ReceiptHandle' => $handle];
+                $validator = isset($opts['validator']) && is_callable($opts['validator']);
 
-            return isset($opts['metadata']) && $opts['metadata'] === $meta && $validator;
-        }))->andReturn($this->messageA);
+                return isset($opts['metadata']) && $opts['metadata'] === $meta && $validator;
+            }))->andReturn($this->messageA);
     }
 
     /**
@@ -133,6 +134,29 @@ class SqsAdapterTest extends TestCase
         ])->andReturn($this->model);
 
         $adapter->acknowledge($this->messages);
+    }
+
+    public function testReject()
+    {
+        $adapter = new SqsAdapter($this->client, 'foo');
+        $url = $this->stubCreateQueue('foo');
+
+        $this->messageA->shouldReceive('getMetadata->get')->once()->with('ReceiptHandle')->andReturn('foo');
+        $this->messageB->shouldReceive('getMetadata->get')->once()->with('ReceiptHandle')->andReturn('bar');
+        $this->messageC->shouldReceive('getMetadata->get')->once()->with('ReceiptHandle')->andReturn('baz');
+
+        $this->model->shouldReceive('get')->once()->with('Failed')->andReturn([]);
+
+        $this->client->shouldReceive('changeMessageVisibilityBatch')->once()->with([
+            'QueueUrl' => $url,
+            'Entries'  => [
+                ['Id' => 0, 'ReceiptHandle' => 'foo', 'VisibilityTimeout' => 0],
+                ['Id' => 1, 'ReceiptHandle' => 'bar', 'VisibilityTimeout' => 0],
+                ['Id' => 2, 'ReceiptHandle' => 'baz', 'VisibilityTimeout' => 0],
+            ],
+        ])->andReturn($this->model);
+
+        $adapter->reject($this->messages);
     }
 
     public function testDequeue()

--- a/tests/unit/Adapter/SqsAdapterTest.php
+++ b/tests/unit/Adapter/SqsAdapterTest.php
@@ -60,13 +60,15 @@ class SqsAdapterTest extends TestCase
      */
     protected function stubCreateDequeueMessage($body, $id, $handle)
     {
-        $this->factory->shouldReceive('createMessage')->once()->with($body,
+        $this->factory->shouldReceive('createMessage')->once()->with(
+            $body,
             m::on(function ($opts) use ($id, $handle) {
                 $meta = ['Attributes' => [], 'MessageAttributes' => [], 'MessageId' => $id, 'ReceiptHandle' => $handle];
                 $validator = isset($opts['validator']) && is_callable($opts['validator']);
 
                 return isset($opts['metadata']) && $opts['metadata'] === $meta && $validator;
-            }))->andReturn($this->messageA);
+            })
+        )->andReturn($this->messageA);
     }
 
     /**

--- a/tests/unit/Handler/ResultAcknowledgementHandlerTest.php
+++ b/tests/unit/Handler/ResultAcknowledgementHandlerTest.php
@@ -69,6 +69,7 @@ class ResultAcknowledgementHandlerTest extends TestCase
         }, $this->handler);
 
         $this->message->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
+        $this->adapter->shouldReceive('reject')->once()->with(m::mustBe([$this->message]));
 
         $handler($this->messages, $this->adapter, function ($msg, Closure $done) use (&$msgs) {
             return false;


### PR DESCRIPTION
Currently we can Acknowledge messages, but we have no way of saying, reject this immediately.

The result is that (for SQS) we need to wait for the VisibilityTimeout for a message to expire.

This PR's adds a `->reject` method to the adapter which (for SQS) ensures that the message fails and gets put back on the queue.